### PR TITLE
[SMS] 2026년 5월 정기점검 문서 반영

### DIFF
--- a/en/api-guide.md
+++ b/en/api-guide.md
@@ -5610,7 +5610,9 @@ Content-Type: application/json;charset=UTF-8
     "templateId": "TemplateId",
     "requestId": "20200201010630ReZQ6KZzAH0",
     "createUser": "CreateUser",
-    "senderGroupingKey": "SenderGroupingKey"
+    "senderGroupingKey": "SenderGroupingKey",
+    "receiverRegion": "DOMESTIC",
+    "countryCode": "82"
   },
   "updateUser": "UpdateUser"
 }
@@ -5633,6 +5635,8 @@ Content-Type: application/json;charset=UTF-8
 | searchParameter.createUser           | String | 100        | Optional | Request Creator of Scheduled Delivery   |
 | searchParameter.senderGroupingKey    | String | 100        | Optional | Sender group key                        |
 | searchParameter.recipientGroupingKey | String | 100        | Optional | Recipient group key                     |
+| searchParameter.receiverRegion       | String | -          | Optional | Domestic/International (DOMESTIC: Domestic, INTERNATIONAL: International) |
+| searchParameter.countryCode          | String | -          | Optional | Country code [[Available countries](./international-sending-policy/#_5)] |
 | updateUser                           | String | 100        | Required | Requester of Scheduled Cancellation     |
 
 #### cURL
@@ -5654,7 +5658,9 @@ curl -X PUT \
         "templateId": "TemplateId",
         "requestId": "20200201010630ReZQ6KZzAH0",
         "createUser": "CreateUser",
-        "senderGroupingKey": "SenderGroupingKey"
+        "senderGroupingKey": "SenderGroupingKey",
+        "receiverRegion": "DOMESTIC",
+        "countryCode": "82"
     },
     "updateUser": "API Guide"
 }'

--- a/ja/api-guide.md
+++ b/ja/api-guide.md
@@ -5597,7 +5597,9 @@ Content-Type: application/json;charset=UTF-8
     "templateId": "TemplateId",
     "requestId": "20200201010630ReZQ6KZzAH0",
     "createUser": "CreateUser",
-    "senderGroupingKey": "SenderGroupingKey"
+    "senderGroupingKey": "SenderGroupingKey",
+    "receiverRegion": "DOMESTIC",
+    "countryCode": "82"
   },
   "updateUser": "UpdateUser"
 }
@@ -5620,6 +5622,8 @@ Content-Type: application/json;charset=UTF-8
 | searchParameter.createUser           | String | 100   | オプション | 予約送信作成者                        |
 | searchParameter.senderGroupingKey    | String | 100   | オプション | 発信者グループキー                      |
 | searchParameter.recipientGroupingKey | String | 100   | オプション | 受信者グループキー                      |
+| searchParameter.receiverRegion       | String | -     | オプション | 国内/国際(DOMESTIC：国内、INTERNATIONAL：国際) |
+| searchParameter.countryCode          | String | -     | オプション | 国コード [[送信可能国](./international-sending-policy/#_5)] |
 | updateUser                           | String | 100   | 必須    | 予約キャンセルリクエスト者                  |
 
 #### cURL
@@ -5641,7 +5645,9 @@ https://sms.api.nhncloudservice.com/sms/v3.0/appKeys/'"${APP_KEY}"'/reservations
         "templateId": "TemplateId",
         "requestId": "20200201010630ReZQ6KZzAH0",
         "createUser": "CreateUser",
-        "senderGroupingKey": "SenderGroupingKey"
+        "senderGroupingKey": "SenderGroupingKey",
+        "receiverRegion": "DOMESTIC",
+        "countryCode": "82"
     },
     "updateUser": "API Guide"
 }'

--- a/ko/api-guide.md
+++ b/ko/api-guide.md
@@ -5615,7 +5615,9 @@ Content-Type: application/json;charset=UTF-8
     "templateId": "TemplateId",
     "requestId": "20200201010630ReZQ6KZzAH0",
     "createUser": "CreateUser",
-    "senderGroupingKey": "SenderGroupingKey"
+    "senderGroupingKey": "SenderGroupingKey",
+    "receiverRegion": "DOMESTIC",
+    "countryCode": "82"
   },
   "updateUser": "UpdateUser"
 }
@@ -5638,6 +5640,8 @@ Content-Type: application/json;charset=UTF-8
 | searchParameter.createUser           | String | 100    | 옵션 | 예약 발송 생성자                       |
 | searchParameter.senderGroupingKey    | String | 100    | 옵션 | 발신자 그룹 키                        |
 | searchParameter.recipientGroupingKey | String | 100    | 옵션 | 수신자 그룹 키                        |
+| searchParameter.receiverRegion       | String | -      | 옵션 | 국내/국제(DOMESTIC: 국내, INTERNATIONAL: 국제) |
+| searchParameter.countryCode          | String | -      | 옵션 | 국가 코드 [[전송 가능 국가](./international-sending-policy/#_5)] |
 | updateUser                           | String | 100    | 필수 | 예약 취소 요청자                       |
 
 #### cURL
@@ -5659,7 +5663,9 @@ curl -X PUT \
         "templateId": "TemplateId",
         "requestId": "20200201010630ReZQ6KZzAH0",
         "createUser": "CreateUser",
-        "senderGroupingKey": "SenderGroupingKey"
+        "senderGroupingKey": "SenderGroupingKey",
+        "receiverRegion": "DOMESTIC",
+        "countryCode": "82"
     },
     "updateUser": "API Guide"
 }'

--- a/zh/api-guide.md
+++ b/zh/api-guide.md
@@ -5433,7 +5433,9 @@ Content-Type: application/json;charset=UTF-8
     "templateId": "TemplateId",
     "requestId": "20200201010630ReZQ6KZzAH0",
     "createUser": "CreateUser",
-    "senderGroupingKey": "SenderGroupingKey"
+    "senderGroupingKey": "SenderGroupingKey",
+    "receiverRegion": "DOMESTIC",
+    "countryCode": "82"
   },
   "updateUser": "UpdateUser"
 }
@@ -5456,6 +5458,8 @@ Content-Type: application/json;charset=UTF-8
 | searchParameter.createUser           | String | 100        | Optional | Request Creator of Scheduled Delivery   |
 | searchParameter.senderGroupingKey    | String | 100        | Optional | Sender group key                        |
 | searchParameter.recipientGroupingKey | String | 100        | Optional | Recipient group key                     |
+| searchParameter.receiverRegion       | String | -          | Optional | Domestic/International (DOMESTIC: Domestic, INTERNATIONAL: International) |
+| searchParameter.countryCode          | String | -          | Optional | Country code [[Available countries](./international-sending-policy/#_5)] |
 | updateUser                           | String | 100        | Required | Requester of Scheduled Cancellation     |
 
 #### cURL
@@ -5477,7 +5481,9 @@ curl -X PUT \
         "templateId": "TemplateId",
         "requestId": "20200201010630ReZQ6KZzAH0",
         "createUser": "CreateUser",
-        "senderGroupingKey": "SenderGroupingKey"
+        "senderGroupingKey": "SenderGroupingKey",
+        "receiverRegion": "DOMESTIC",
+        "countryCode": "82"
     },
     "updateUser": "API Guide"
 }'


### PR DESCRIPTION
## Summary
- 예약 발송 취소 - 다중 필터 API에 `receiverRegion`(국내/국제), `countryCode`(국가 코드) request parameter 추가
- Request body JSON 예시, 파라미터 테이블, cURL 예시 3곳 수정

## 관련 Task
- [Notification-개발/10034 - [SMS] 예약 발송 취소 - 다중 필터 public api 가이드 수정](https://nhnent.dooray.com/project/tasks/4159736401643606962)

🤖 Generated with [Claude Code](https://claude.com/claude-code)