### PR TITLE
chore(pre-align): align-v2 heading structure (api-guide-v2.3.md) with ko

### DIFF
--- a/en/api-guide-v2.3.md
+++ b/en/api-guide-v2.3.md
@@ -1782,15 +1782,15 @@ curl -X GET \
 
 <!-- TODO: translate body -->
 
-<a id="message-search-based-on-result-update"></a>
+<a id="query-messages-based-on-result-update"></a>
 
-## Message Search Based on Result Update
+## Query Messages Based on Result Update
 
 <!-- TODO: translate body -->
 
-<a id="message-search"></a>
+<a id="query-messages"></a>
 
-### Message Search
+### Query Messages
 
 <!-- TODO: translate body -->
 

--- a/ja/api-guide-v2.3.md
+++ b/ja/api-guide-v2.3.md
@@ -1682,14 +1682,14 @@ curl -X POST \
 }'
 ```
 
-<a id="message-search-based-on-result-update"></a>
+<a id="query-messages-based-on-result-update"></a>
 
 ## 結果アップデート基準メッセージ照会
 
 * 該当APIは、メッセージ送信結果アップデート時間基準で照会されます。
 * 端末送信結果をサービスの外で使用する場合、このAPIを使用してください。
 
-<a id="message-search"></a>
+<a id="query-messages"></a>
 
 ### メッセージ照会
 
@@ -2491,6 +2491,8 @@ Content-Type: application/json;charset=UTF-8
 | categoryDesc     | 	String  | 100    | 	オプション | 	カテゴリー名                    |
 | useYn            | 	String  | 1      | 	必須    | 使用有無(Y/N)                  |
 | createUser       | 	String  | 100    | オプション  | 登録したユーザー                   |
+
+<a id="curl-19"></a>
 
 #### cURL
 

--- a/ko/api-guide-v2.3.md
+++ b/ko/api-guide-v2.3.md
@@ -1685,14 +1685,14 @@ curl -X POST \
 }'
 ```
 
-<a id="message-search-based-on-result-update"></a>
+<a id="query-messages-based-on-result-update"></a>
 
 ## 결과 업데이트 기준 메시지 검색
 
 * 해당 API는 메시지 발송 결과 업데이트 시간 기준으로 검색됩니다.
 * 단말기 발송 결과를 서비스에서 가져가 사용하시는 경우 이 API를 사용해주세요.
 
-<a id="message-search"></a>
+<a id="query-messages"></a>
 
 ### 메시지 검색
 


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Body text is never modified.** The model only sees heading outlines; edits apply to heading lines (and `<!-- TODO: translate body -->` stubs for missing sections) only.

## Analysis

| | |
| --- | --- |
| Engine | `claude-code (CLI)` |
| Model | `claude-sonnet-4-6` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `alpha` |
| Scope | 1 doc(s) scanned · 3 file(s) changed |
| Self-verify | ⚠️ 2 mismatch(es) remain |
| Jenkins build | http://testlab.cloud.toastoven.net:8080/job/user-guide-agent/job/align-heading/job/260521/93/ |
| Generated | 2026-06-16T03:13:21 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`alpha`): [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FSMS%2Fblob%2Falpha%2Fko%2Fapi-guide-v2.3.md&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FSMS%2Fpull%2F244&source=ko&langs=en%2Cja)

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra demoted | extra removed | verify |
| --- | --: | --: | --: | --: | --: | --: | --: | :--: |
| `ko/api-guide-v2.3.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/api-guide-v2.3.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/api-guide-v2.3.md` | 0 | 0 | 0 | 1 | 0 | 0 | 0 | ⚠️ 2 |

<details><summary>남은 불일치 (검토 필요)</summary>

- `ja/api-guide-v2.3.md`:
  - missing_in_target (ko#93/ja#None)
  - extra_in_target (ko#None/ja#94)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/SMS`