### PR TITLE
chore(pre-align): align heading structure (11 docs) with ko

### DIFF
--- a/en/api-guide-v2.3.md
+++ b/en/api-guide-v2.3.md
@@ -1,3 +1,5 @@
+<!-- pre-align:aligned sig=e49e0a0eb044 -->
+
 <a id="notification-sms-api-v23-guide"></a>
 ## Notification > SMS > API v2.3 Guide { #notification-sms-api-v23-guide }
 
@@ -3814,79 +3816,6 @@ curl -X GET \
 | body.data.events[].{statsCriteriaValue}.sentFailed | 	Integer | 	Number of failures                                                                                                                                          |
 | body.data.events[].{statsCriteriaValue}.received   | 	Integer | 	Number of successes                                                                                                                                         |
 | body.data.events[].{statsCriteriaValue}.pending    | 	Integer | 	Number of pending items                                                                                                                                     |
-
-<a id="oldquery-integrated-statistics"></a>
-### (Old)Query Integrated Statistics { #oldquery-integrated-statistics }
-
-<a id="oldquery-integrated-statistics-request"></a>
-#### Request
-
-[URL]
-
-| Http method | 	URI                                                                                                                                                                 |
-|-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| GET         | 	/sms/v2.3/appKeys/{appKey/statistics/view?searchType={searchType}&from={from}&to={to}&messageTypes={messageType}&contentTypes={contentType}&templateId={templateId} |
-
-[Path parameter]
-
-| Value  | Type    | Description     |
-|--------|---------|-----------------|
-| appKey | 	String | Original appkey |
-
-[Query parameter]
-
-| Value       | Type   | 	Max Length | Required | Description                                                                                     |
-|-------------|--------|-------------|----------|-------------------------------------------------------------------------------------------------|
-| searchType  | String | 10          | O        | Type of statistics <br/>DATE:By date, TIME:By time, DAY:By day                                  |
-| from        | String | -           | O        | Start date of query statistics<br/>yyyy-MM-dd HH:mm                                             |
-| to          | String | -           | O        | End date of query statistics<br/>yyyy-MM-dd HH:mm                                               |
-| messageType | String | 10          | X        | Message type<br/>SMS: Short messages, LMS: Long messages, MMS: Attachment, AUTH: Authentication |
-| contentType | String | 10          | X        | Content type <br/>NORMAL: General, AD: Advertisement                                            |
-| templateId  | String | 50          | X        | Template ID                                                                                     |
-
-<a id="oldquery-integrated-statistics-response"></a>
-#### Response
-
-```json
-{
-  "header": {
-    "isSuccessful": true,
-    "resultCode": 0,
-    "resultMessage": "SUCCESS"
-  },
-  "body": {
-    "data": [
-      {
-        "divisionName": "2018-06-01",
-        "statisticsView": {
-          "requestedCount": 10,
-          "succeedCount": 10,
-          "failedCount": 0,
-          "pendingCount": 0,
-          "succeedRate": "100.00",
-          "failedRate": "0.00",
-          "pendingRate": "0.00"
-        }
-      }
-    ]
-  }
-}
-```
-
-| Value                      | Type     | Description                      |
-|----------------------------|----------|----------------------------------|
-| header.isSuccessful        | 	Boolean | Successful or not                |
-| header.resultCode          | 	Integer | Failure code                     |
-| header.resultMessage       | 	String  | Failure message                  |
-| body.data[].divisionName   | String   | Display name<br/>Date, time, Day |
-| body.data[].statisticsView | Object   |                                  |
-| body.data[].requestedCount | Integer  | Number of requests               |
-| body.data[].succeedCount   | Integer  | Success count                    |
-| body.data[].failedCount    | Integer  | Failure count                    |
-| body.data[].pendingCount   | Integer  | Delivery count                   |
-| body.data[].succeedRate    | String   | Success rate                     |
-| body.data[].failedRate     | String   | Failure rate                     |
-| body.data[].pendingRate    | String   | Delivery rate                    |
 
 <a id="scheduled-delivery"></a>
 ## Scheduled Delivery { #scheduled-delivery }

--- a/en/api-guide-v2.4.md
+++ b/en/api-guide-v2.4.md
@@ -1,3 +1,5 @@
+<!-- pre-align:aligned sig=d18815424bd1 -->
+
 <a id="notification-sms-api-v24-guide"></a>
 ## Notification > SMS > API v2.4 Guide { #notification-sms-api-v24-guide }
 
@@ -3799,79 +3801,6 @@ curl -X GET \
 | body.data.events[].{statsCriteriaValue}.sentFailed | 	Integer | 	Number of failures                                                                                                                                          |
 | body.data.events[].{statsCriteriaValue}.received   | 	Integer | 	Number of successes                                                                                                                                         |
 | body.data.events[].{statsCriteriaValue}.pending    | 	Integer | 	Number of pending items                                                                                                                                     |
-
-<a id="oldquery-integrated-statistics"></a>
-### (Old)Query Integrated Statistics { #oldquery-integrated-statistics }
-
-<a id="oldquery-integrated-statistics-request"></a>
-#### Request
-
-[URL]
-
-| Http method | 	URI                                                                                                                                                                 |
-|-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| GET         | 	/sms/v2.4/appKeys/{appKey/statistics/view?searchType={searchType}&from={from}&to={to}&messageTypes={messageType}&contentTypes={contentType}&templateId={templateId} |
-
-[Path parameter]
-
-| Value  | Type    | Description     |
-|--------|---------|-----------------|
-| appKey | 	String | Original appkey |
-
-[Query parameter]
-
-| Value       | Type   | 	Max Length | Required | Description                                                                                     |
-|-------------|--------|-------------|----------|-------------------------------------------------------------------------------------------------|
-| searchType  | String | 10          | O        | Type of statistics <br/>DATE:By date, TIME:By time, DAY:By day                                  |
-| from        | String | -           | O        | Start date of query statistics<br/>yyyy-MM-dd HH:mm                                             |
-| to          | String | -           | O        | End date of query statistics<br/>yyyy-MM-dd HH:mm                                               |
-| messageType | String | 10          | X        | Message type<br/>SMS: Short messages, LMS: Long messages, MMS: Attachment, AUTH: Authentication |
-| contentType | String | 10          | X        | Content type <br/>NORMAL: General, AD: Advertisement                                            |
-| templateId  | String | 50          | X        | Template ID                                                                                     |
-
-<a id="oldquery-integrated-statistics-response"></a>
-#### Response
-
-```json
-{
-  "header": {
-    "isSuccessful": true,
-    "resultCode": 0,
-    "resultMessage": "SUCCESS"
-  },
-  "body": {
-    "data": [
-      {
-        "divisionName": "2018-06-01",
-        "statisticsView": {
-          "requestedCount": 10,
-          "succeedCount": 10,
-          "failedCount": 0,
-          "pendingCount": 0,
-          "succeedRate": "100.00",
-          "failedRate": "0.00",
-          "pendingRate": "0.00"
-        }
-      }
-    ]
-  }
-}
-```
-
-| Value                      | Type     | Description                      |
-|----------------------------|----------|----------------------------------|
-| header.isSuccessful        | 	Boolean | Successful or not                |
-| header.resultCode          | 	Integer | Failure code                     |
-| header.resultMessage       | 	String  | Failure message                  |
-| body.data[].divisionName   | String   | Display name<br/>Date, time, Day |
-| body.data[].statisticsView | Object   |                                  |
-| body.data[].requestedCount | Integer  | Number of requests               |
-| body.data[].succeedCount   | Integer  | Success count                    |
-| body.data[].failedCount    | Integer  | Failure count                    |
-| body.data[].pendingCount   | Integer  | Delivery count                   |
-| body.data[].succeedRate    | String   | Success rate                     |
-| body.data[].failedRate     | String   | Failure rate                     |
-| body.data[].pendingRate    | String   | Delivery rate                    |
 
 <a id="scheduled-delivery"></a>
 ## Scheduled Delivery { #scheduled-delivery }

--- a/en/api-guide.md
+++ b/en/api-guide.md
@@ -1,4 +1,4 @@
-<!-- pre-align:aligned sig=842985799b6c -->
+<!-- pre-align:aligned sig=c5be1a623430 -->
 
 <a id="notification-sms-api-v30-guide"></a>
 ## Notification > SMS > API v3.0 Guide { #notification-sms-api-v30-guide }
@@ -5338,93 +5338,6 @@ curl -X GET \
 | events.{statsCriteriaValue}.CONCAT          | Integer | O        | Number of successes                                              |
 | events.{statsCriteriaValue}.READY           | Integer | O        | Number of conversion rate collection requests successfuly sent   |
 | events.{statsCriteriaValue}.CONVERTED       | Integer | O        | Number of converted items                                        |
-
-<a id="oldquery-integrated-statistics"></a>
-### (Old)Query Integrated Statistics { #oldquery-integrated-statistics }
-
-<a id="oldquery-integrated-statistics-request"></a>
-#### Request
-
-[URL]
-
-| Http method | 	URI                                                                                                                                                                  |
-|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| GET         | 	/sms/v3.0/appKeys/{appKey}/statistics/view?searchType={searchType}&from={from}&to={to}&messageTypes={messageType}&contentTypes={contentType}&templateId={templateId} |
-
-[Path parameter]
-
-| Value  | 	Type   | 	Description     |
-|--------|---------|------------------|
-| appKey | 	String | 	Original appkey |
-
-[Header]
-
-```json
-{
-  "X-Secret-Key": "{secret-key}"
-}
-```
-
-| Value        | Type    | Description          |
-|--------------|---------|----------------------|
-| X-Secret-Key | 	String | 	Original secret key |
-
-[Query parameter]
-
-| Value       | Type   | 	Max Length | Required | Description                                                                                     |
-|-------------|--------|-------------|----------|-------------------------------------------------------------------------------------------------|
-| searchType  | String | 10          | O        | Type of statistics <br/>DATE:By date, TIME:By time, DAY:By day                                  |
-| from        | String | -           | O        | Start date of query statistics<br/>yyyy-MM-dd HH:mm                                             |
-| to          | String | -           | O        | End date of query statistics<br/>yyyy-MM-dd HH:mm                                               |
-| messageType | String | 10          | X        | Message type<br/>SMS: Short messages, LMS: Long messages, MMS: Attachment, AUTH: Authentication |
-| contentType | String | 10          | X        | Content type <br/>NORMAL: General, AD: Advertisement                                            |
-| templateId  | String | 50          | X        | Template ID                                                                                     |
-
-<a id="oldquery-integrated-statistics-response"></a>
-#### Response
-
-```json
-{
-  "header": {
-    "isSuccessful": true,
-    "resultCode": 0,
-    "resultMessage": "SUCCESS"
-  },
-  "body": {
-    "data": [
-      {
-        "divisionName": "2018-06-01",
-        "statisticsView": {
-          "requestedCount": 10,
-          "succeedCount": 10,
-          "failedCount": 0,
-          "pendingCount": 0,
-          "succeedRate": "100.00",
-          "failedRate": "0.00",
-          "pendingRate": "0.00"
-        }
-      }
-    ]
-  }
-}
-```
-
-| Value                      | Type    | Not Null | Description                      |
-|----------------------------|---------|----------|----------------------------------|
-| header                     | Object  | O        | Header area                      |
-| header.isSuccessful        | Boolean | O        | Successful or not                |
-| header.resultCode          | Integer | O        | Failure code                     |
-| header.resultMessage       | String  | O        | Failure message                  |
-| body                       | Object  | X        | Body area                        |
-| body.data[].divisionName   | String  | X        | Display name<br/>Date, time, Day |
-| body.data[].statisticsView | Object  | X        |                                  |
-| body.data[].requestedCount | Integer | X        | Number of requests               |
-| body.data[].succeedCount   | Integer | X        | Success count                    |
-| body.data[].failedCount    | Integer | X        | Failure count                    |
-| body.data[].pendingCount   | Integer | X        | Delivery count                   |
-| body.data[].succeedRate    | String  | X        | Success rate                     |
-| body.data[].failedRate     | String  | X        | Failure rate                     |
-| body.data[].pendingRate    | String  | X        | Delivery rate                    |
 
 <a id="scheduled-delivery"></a>
 ## Scheduled Delivery { #scheduled-delivery }

--- a/en/release-notes.md
+++ b/en/release-notes.md
@@ -1,3 +1,5 @@
+<!-- pre-align:aligned sig=bf7aa4e53faf -->
+
 <a id="notification-sms-release-notes"></a>
 ## Notification > SMS > Release Notes { #notification-sms-release-notes }
 

--- a/ja/api-guide-v2.3.md
+++ b/ja/api-guide-v2.3.md
@@ -1,3 +1,5 @@
+<!-- pre-align:aligned sig=e49e0a0eb044 -->
+
 <a id="notification-sms-api-v23-guide"></a>
 ## Notification > SMS > API v2.3ガイド { #notification-sms-api-v23-guide }
 
@@ -3790,79 +3792,6 @@ curl -X GET \
 | body.data.events[].{statsCriteriaValue}.sentFailed | 	Integer | 	失敗数                                                                                                             |
 | body.data.events[].{statsCriteriaValue}.received   | 	Integer | 	成功数                                                                                                             |
 | body.data.events[].{statsCriteriaValue}.pending    | 	Integer | 	送信中の数                                                                                                           |
-
-<a id="oldquery-integrated-statistics"></a>
-### (旧)統合統計照会 { #oldquery-integrated-statistics }
-
-<a id="oldquery-integrated-statistics-request"></a>
-#### リクエスト
-
-[URL]
-
-| Http method | 	URI                                                                                                                                                                  |
-|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| GET         | 	/sms/v2.3/appKeys/{appKey}/statistics/view?searchType={searchType}&from={from}&to={to}&messageTypes={messageType}&contentTypes={contentType}&templateId={templateId} |
-
-[Path parameter]
-
-| 値      | 	タイプ    | 	説明            |
-|--------|---------|----------------|
-| appKey | 	String | 	固有のアプリケーションキー |
-
-[Query parameter]
-
-| 値           | 	タイプ   | 	最大 | 必須 | 説明                                             |
-|-------------|--------|-----|----|------------------------------------------------|
-| searchType  | String | 10  | O  | 統計区分<br/>DATE：日付別、TIME：時間別、DAY：曜日別             |
-| from        | String | -   | O  | 統計照会開始日時<br/>yyyy-MM-dd HH:mm                  |
-| to          | String | -   | O  | 統計照会の終了日時<br/>yyyy-MM-dd HH:mm                 |
-| messageType | String | 10  | X  | メッセージタイプ<br/>SMS：短文、LMS：長文、MMS：添付ファイル、AUTH：認証用 |
-| contentType | String | 10  | X  | コンテンツタイプ<br/>NORMAL：一般、AD：広告                   |
-| templateId  | String | 50  | X  | テンプレートID                                       |
-
-<a id="oldquery-integrated-statistics-response"></a>
-#### レスポンス
-
-```json
-{
-  "header": {
-    "isSuccessful": true,
-    "resultCode": 0,
-    "resultMessage": "SUCCESS"
-  },
-  "body": {
-    "data": [
-      {
-        "divisionName": "2018-06-01",
-        "statisticsView": {
-          "requestedCount": 10,
-          "succeedCount": 10,
-          "failedCount": 0,
-          "pendingCount": 0,
-          "succeedRate": "100.00",
-          "failedRate": "0.00",
-          "pendingRate": "0.00"
-        }
-      }
-    ]
-  }
-}
-```
-
-| 値                          | タイプ      | 説明               |
-|----------------------------|----------|------------------|
-| header.isSuccessful        | 	Boolean | 	成否              |
-| header.resultCode          | 	Integer | 	失敗コード           |
-| header.resultMessage       | 	String  | 	失敗メッセージ         |
-| body.data[].divisionName   | String   | 表示名<br/>日付、時間、曜日 |
-| body.data[].statisticsView | Object   |                  |
-| body.data[].requestedCount | Integer  | リクエスト数           |
-| body.data[].succeedCount   | Integer  | 成功数              |
-| body.data[].failedCount    | Integer  | 失敗数              |
-| body.data[].pendingCount   | Integer  | 送信中の数            |
-| body.data[].succeedRate    | String   | 成功比率             |
-| body.data[].failedRate     | String   | 失敗比率             |
-| body.data[].pendingRate    | String   | 送信中の比率           |
 
 <a id="scheduled-delivery"></a>
 ## 予約送信 { #scheduled-delivery }

--- a/ja/api-guide-v2.4.md
+++ b/ja/api-guide-v2.4.md
@@ -1,3 +1,5 @@
+<!-- pre-align:aligned sig=d18815424bd1 -->
+
 <a id="notification-sms-api-v24-guide"></a>
 ## Notification > SMS > API v2.4ガイド { #notification-sms-api-v24-guide }
 
@@ -3784,79 +3786,6 @@ curl -X GET \
 | body.data.events[].{statsCriteriaValue}.sentFailed | 	Integer | 	失敗数                                                                                                             |
 | body.data.events[].{statsCriteriaValue}.received   | 	Integer | 	成功数                                                                                                             |
 | body.data.events[].{statsCriteriaValue}.pending    | 	Integer | 	送信中の数                                                                                                           |
-
-<a id="oldquery-integrated-statistics"></a>
-### (旧)統合統計照会 { #oldquery-integrated-statistics }
-
-<a id="oldquery-integrated-statistics-request"></a>
-#### リクエスト
-
-[URL]
-
-| Http method | 	URI                                                                                                                                                                  |
-|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| GET         | 	/sms/v2.4/appKeys/{appKey}/statistics/view?searchType={searchType}&from={from}&to={to}&messageTypes={messageType}&contentTypes={contentType}&templateId={templateId} |
-
-[Path parameter]
-
-| 値      | 	タイプ    | 	説明            |
-|--------|---------|----------------|
-| appKey | 	String | 	固有のアプリケーションキー |
-
-[Query parameter]
-
-| 値           | 	タイプ   | 	最大 | 必須 | 説明                                             |
-|-------------|--------|-----|----|------------------------------------------------|
-| searchType  | String | 10  | O  | 統計区分<br/>DATE：日付別、TIME：時間別、DAY：曜日別             |
-| from        | String | -   | O  | 統計照会開始日時<br/>yyyy-MM-dd HH:mm                  |
-| to          | String | -   | O  | 統計照会の終了日時<br/>yyyy-MM-dd HH:mm                 |
-| messageType | String | 10  | X  | メッセージタイプ<br/>SMS：短文、LMS：長文、MMS：添付ファイル、AUTH：認証用 |
-| contentType | String | 10  | X  | コンテンツタイプ<br/>NORMAL：一般、AD：広告                   |
-| templateId  | String | 50  | X  | テンプレートID                                       |
-
-<a id="oldquery-integrated-statistics-response"></a>
-#### レスポンス
-
-```json
-{
-  "header": {
-    "isSuccessful": true,
-    "resultCode": 0,
-    "resultMessage": "SUCCESS"
-  },
-  "body": {
-    "data": [
-      {
-        "divisionName": "2018-06-01",
-        "statisticsView": {
-          "requestedCount": 10,
-          "succeedCount": 10,
-          "failedCount": 0,
-          "pendingCount": 0,
-          "succeedRate": "100.00",
-          "failedRate": "0.00",
-          "pendingRate": "0.00"
-        }
-      }
-    ]
-  }
-}
-```
-
-| 値                          | タイプ      | 説明               |
-|----------------------------|----------|------------------|
-| header.isSuccessful        | 	Boolean | 	成否              |
-| header.resultCode          | 	Integer | 	失敗コード           |
-| header.resultMessage       | 	String  | 	失敗メッセージ         |
-| body.data[].divisionName   | String   | 表示名<br/>日付、時間、曜日 |
-| body.data[].statisticsView | Object   |                  |
-| body.data[].requestedCount | Integer  | リクエスト数           |
-| body.data[].succeedCount   | Integer  | 成功数              |
-| body.data[].failedCount    | Integer  | 失敗数              |
-| body.data[].pendingCount   | Integer  | 送信中の数            |
-| body.data[].succeedRate    | String   | 成功比率             |
-| body.data[].failedRate     | String   | 失敗比率             |
-| body.data[].pendingRate    | String   | 送信中の比率           |
 
 <a id="scheduled-delivery"></a>
 ## 予約送信 { #scheduled-delivery }

--- a/ja/api-guide.md
+++ b/ja/api-guide.md
@@ -1,4 +1,4 @@
-<!-- pre-align:aligned sig=842985799b6c -->
+<!-- pre-align:aligned sig=c5be1a623430 -->
 
 <a id="notification-sms-api-v30-guide"></a>
 ## Notification > SMS > API v3.0 Guide { #notification-sms-api-v30-guide }
@@ -5326,93 +5326,6 @@ https://sms.api.nhncloudservice.com/sms/v3.0/appKeys/'"${APP_KEY}"'/stats?statis
 | events.{statsCriteriaValue}.CONCAT      | Integer | O        | 実受信成功数                                        |
 | events.{statsCriteriaValue}.READY       | Integer | O        | コンバージョン率収集リクエストの送信成功数           |
 | events.{statsCriteriaValue}.CONVERTED   | Integer | O        | コンバージョン数                                    |
-
-<a id="oldquery-integrated-statistics"></a>
-### (旧)統合統計検索 { #oldquery-integrated-statistics }
-
-<a id="oldquery-integrated-statistics-request"></a>
-#### リクエスト
-
-[URL]
-
-| Http method | 	URI                                                                                                                                                                  |
-|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| GET         | 	/sms/v3.0/appKeys/{appKey}/statistics/view?searchType={searchType}&from={from}&to={to}&messageTypes={messageType}&contentTypes={contentType}&templateId={templateId} |
-
-[Path parameter]
-
-| 値      | 	タイプ    | 	説明            |
-|--------|---------|----------------|
-| appKey | 	String | 	固有のアプリケーションキー |
-
-[Header]
-
-```json
-{
-"X-Secret-Key": "{secret-key}"
-}
-```
-
-| 値            | 	タイプ    | 	説明          |
-|--------------|---------|--------------|
-| X-Secret-Key | 	String | 	固有のシークレットキー |
-
-[Query parameter]
-
-| 値           | 	タイプ   | 	最大長さ | 必須 | 説明                                              |
-|-------------|--------|-------|----|-------------------------------------------------|
-| searchType  | String | 10    | O  | 統計区分<br/>DATE：日別、TIME：時間別、 DAY：曜日別              |
-| from        | String | -     | O  | 統計検索開始日<br/>yyyy-MM-dd HH:mm                    |
-| to          | String | -     | O  | 統計検索終了日<br/>yyyy-MM-dd HH:mm                    |
-| messageType | String | 10    | X  | メッセージタイプ<br/>SMS：短文、LMS：長文、MMS：添付ファイル、 AUTH：認証用 |
-| contentType | String | 10    | X  | コンテンツタイプ<br/>NORMAL：一般、 AD：広告                   |
-| templateId  | String | 50    | X  | テンプレートID                                        |
-
-<a id="oldquery-integrated-statistics-response"></a>
-#### レスポンス
-
-```json
-{
-  "header": {
-    "isSuccessful": true,
-    "resultCode": 0,
-    "resultMessage": "SUCCESS"
-  },
-  "body": {
-    "data": [
-      {
-        "divisionName": "2018-06-01",
-        "statisticsView": {
-          "requestedCount": 10,
-          "succeedCount": 10,
-          "failedCount": 0,
-          "pendingCount": 0,
-          "succeedRate": "100.00",
-          "failedRate": "0.00",
-          "pendingRate": "0.00"
-        }
-      }
-    ]
-  }
-}
-```
-
-| 値                          | タイプ    | Not Null | 説明               |
-|----------------------------|---------|----------|--------------------|
-| header                     | Object  | O        | ヘッダ領域            |
-| header.isSuccessful        | Boolean | O        | 成否                |
-| header.resultCode          | Integer | O        | 失敗コード            |
-| header.resultMessage       | String  | O        | 失敗メッセージ         |
-| body                       | Object  | X        | 本文領域              |
-| body.data[].divisionName   | String  | X        | 表示名<br/>日、時間、曜日 |
-| body.data[].statisticsView | Object  | X        |                     |
-| body.data[].requestedCount | Integer | X        | リクエスト数           |
-| body.data[].succeedCount   | Integer | X        | 成功数               |
-| body.data[].failedCount    | Integer | X        | 失敗数               |
-| body.data[].pendingCount   | Integer | X        | 送信中の数            |
-| body.data[].succeedRate    | String  | X        | 成功比率              |
-| body.data[].failedRate     | String  | X        | 失敗比率              |
-| body.data[].pendingRate    | String  | X        | 送信中の比率           |
 
 <a id="scheduled-delivery"></a>
 ## 予約送信 { #scheduled-delivery }

--- a/ja/release-notes.md
+++ b/ja/release-notes.md
@@ -1,3 +1,5 @@
+<!-- pre-align:aligned sig=bf7aa4e53faf -->
+
 <a id="notification-sms-release-notes"></a>
 ## Notification > SMS > リリースノート { #notification-sms-release-notes }
 

--- a/ko/api-guide-v2.3.md
+++ b/ko/api-guide-v2.3.md
@@ -1,3 +1,5 @@
+<!-- pre-align:aligned sig=e49e0a0eb044 -->
+
 <a id="notification-sms-api-v23-guide"></a>
 ## Notification > SMS > API v2.3 Guide { #notification-sms-api-v23-guide }
 
@@ -3789,6 +3791,7 @@ curl -X GET \
 | body.data.events[].{statsCriteriaValue}.received   | 	Integer | 	성공 개수                                                                                                              |
 | body.data.events[].{statsCriteriaValue}.pending    | 	Integer | 	발송 중 개수                                                                                                            |
 
+<a id="scheduled-delivery"></a>
 ## 예약 발송 { #scheduled-delivery }
 
 <a id="list-scheduled-delivery"></a>

--- a/ko/api-guide-v2.4.md
+++ b/ko/api-guide-v2.4.md
@@ -1,3 +1,5 @@
+<!-- pre-align:aligned sig=d18815424bd1 -->
+
 <a id="notification-sms-api-v24-guide"></a>
 ## Notification > SMS > API v2.4 Guide { #notification-sms-api-v24-guide }
 
@@ -3794,6 +3796,7 @@ curl -X GET \
 | body.data.events[].{statsCriteriaValue}.received   | 	Integer | 	성공 개수                                                                                                              |
 | body.data.events[].{statsCriteriaValue}.pending    | 	Integer | 	발송 중 개수                                                                                                            |
 
+<a id="scheduled-delivery"></a>
 ## 예약 발송 { #scheduled-delivery }
 
 <a id="list-scheduled-delivery"></a>

--- a/ko/api-guide.md
+++ b/ko/api-guide.md
@@ -1,4 +1,4 @@
-<!-- pre-align:aligned sig=842985799b6c -->
+<!-- pre-align:aligned sig=c5be1a623430 -->
 
 <a id="notification-sms-api-v30-guide"></a>
 ## Notification > SMS > API v3.0 Guide { #notification-sms-api-v30-guide }

--- a/ko/release-notes.md
+++ b/ko/release-notes.md
@@ -1,3 +1,5 @@
+<!-- pre-align:aligned sig=bf7aa4e53faf -->
+
 <a id="notification-sms-release-notes"></a>
 ## Notification > SMS > 릴리스 노트 { #notification-sms-release-notes }
 


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Body text is never modified.** The model only sees heading outlines; edits apply to heading lines (and `<!-- TODO: translate body -->` stubs for missing sections) only.

## Analysis

| | |
| --- | --- |
| Engine | `claude-code (CLI)` |
| Model | `claude-sonnet-4-6` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `alpha` |
| Scope | 11 doc(s) scanned · 12 file(s) changed · 7 unchanged |
| Self-verify | ✅ all aligned |
| Jenkins build | http://cd.cloud.toastoven.net:8080/job/content_deploy/job/align-heading/job/main/193/ |
| Generated | 2026-07-24T02:24:49 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`alpha`): [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FSMS%2Ftree%2Falpha&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FSMS%2Fpull%2F263&source=ko&langs=en%2Cja)

## Link check

이 PR 의 링크 상태: [Link Check ↗](http://content-agent.cloud.toastoven.net:7700/link-check?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FSMS%2Fpull%2F263&ref=alpha&langs=en%2Cja)

<!-- LINK_CHECK_SUMMARY -->

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra demoted | extra removed | marker | verify |
| --- | --: | --: | --: | --: | --: | --: | --: | :--: | :--: |
| `ko/api-guide-v2.3.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `en/api-guide-v2.3.md` | 0 | 0 | 0 | 0 | 0 | 0 | 3 | ✅ | ✅ |
| `ja/api-guide-v2.3.md` | 0 | 0 | 0 | 0 | 0 | 0 | 3 | ✅ | ✅ |
| `ko/api-guide-v2.4.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `en/api-guide-v2.4.md` | 0 | 0 | 0 | 0 | 0 | 0 | 3 | ✅ | ✅ |
| `ja/api-guide-v2.4.md` | 0 | 0 | 0 | 0 | 0 | 0 | 3 | ✅ | ✅ |
| `ko/api-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `en/api-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 3 | ✅ | ✅ |
| `ja/api-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 3 | ✅ | ✅ |
| `ko/release-notes.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `en/release-notes.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ja/release-notes.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |

<details><summary>변경 없이 건너뛴 문서 (7) — 이미 `ko`와 정렬됨 / 대상 파일 없음 (PR에서 제외)</summary>

- `Overview.md`
- `api-guide-v2.2.md`
- `console-guide.md`
- `error-code.md`
- `international-sending-policy.md`
- `sending-policy.md`
- `webhook.md`

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/SMS`