### PR TITLE
#Notification-개발/11114 [SMS] error-code 가이드에 do-convert 응답 코드 -2007(Not exist data) 추가

### DIFF
--- a/ko/error-code.md
+++ b/ko/error-code.md
@@ -31,6 +31,7 @@
 | 발송/조회 | false | -2004 | 첨부 파일이 만료되거나 존재하지 않는 경우 | File is expired or does not exist. | 
 | 발송/조회 | false | -2005 | 첨부 파일 사이즈가 300KB가 넘는 경우 | The file size must be greater than 0 and less than 300KB. |
 | 발송/조회 | false | -2006 | 템플릿에 설정된 발송 유형과 요청온 발송 유형이 맞지 않는 경우 | Invalid template type. |
+| 발송/조회 | false | -2007 | 요청한 데이터가 존재하지 않는 경우 | Not exist data. |
 | 발송/조회 | false | -2008 | 요청 ID(requestId)가 잘못된 경우 | Invalid requestId. |
 | 발송/조회 | false | -2009 | 첨부 파일 업로드 도중 서버 오류로 인해 정상적으로 업로드되지 않은 경우 | Upload attach file error. | 
 | 발송/조회 | false | -2010 | 첨부 파일 업로드 유형이 잘못된 경우(서버 오류) | Upload attach file type can not be empty. |


### PR DESCRIPTION
## Dooray Issue

* http://nhnent.dooray.com/popup/project/projects/Notification-개발/11114

## Checklist (필수)

* [x] base branch 확인 (alpha)
* [x] Dooray Issue 링크 작성
* [x] 로컬 실행 및 변경사항 확인
* [x] Labels 등록 (documentation)
* [x] PR 셀프 리뷰 진행

## Comment

* QA 자동화 중 do-convert API(`/sender/sms/do-convert`)가 반환하는 `-2007`(Not exist data)이 가이드 에러코드 표에 누락되어 있어 추가함
* 전환 대상이 아닌 데이터(useConversion=false 발송건)나 존재하지 않는 데이터 요청 시 반환되는 코드임
* `ko/error-code.md` 만 수정 (en/ja 번역은 번역팀 소관)